### PR TITLE
[fix] handle possible epipe exception during ssl write

### DIFF
--- a/lib/fluent/plugin/out_logentries.rb
+++ b/lib/fluent/plugin/out_logentries.rb
@@ -127,7 +127,7 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
     retries = 0
     begin
       client.write("#{token} #{data} \n")
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
+    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE => e
       if retries < @max_retries
         retries += 1
         @_socket = nil

--- a/lib/fluent/plugin/out_logentries.rb
+++ b/lib/fluent/plugin/out_logentries.rb
@@ -16,6 +16,7 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :max_retries,    :integer, :default => 3
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
+  config_param :default_token,  :string,  :default => nil
 
   SSL_HOST    = "api.logentries.com"
   NO_SSL_HOST = "data.logentries.com"
@@ -102,7 +103,7 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
       end
     end
 
-    return nil
+    return default_token
   end
 
   # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.


### PR DESCRIPTION
A small patch which should resolve the following exception.

```bash
2015-07-12 05:52:06 +0000 [info]: Token(s) list updated.
2015-07-12 13:57:12 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-12 13:57:13 +0000 error_class="Errno::EPIPE" error="Broken pipe" plugin_id="object:3fb600e80350"
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/lib/ruby/2.2.0/openssl/buffering.rb:326:in `syswrite'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/lib/ruby/2.2.0/openssl/buffering.rb:326:in `do_write'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/lib/ruby/2.2.0/openssl/buffering.rb:344:in `write'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:129:in `send_logentries'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:121:in `block in write'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/plugin/buf_memory.rb:61:in `feed_each'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/plugin/buf_memory.rb:61:in `msgpack_each'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:112:in `write'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/buffer.rb:325:in `write_chunk'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/buffer.rb:304:in `pop'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/output.rb:321:in `try_flush'
  2015-07-12 13:57:12 +0000 [warn]: /usr/local/bundle/gems/fluentd-0.12.12/lib/fluent/output.rb:140:in `run'
2015-07-12 13:57:13 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-12 13:57:15 +0000 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3fb600e80350"
  2015-07-12 13:57:13 +0000 [warn]: suppressed same stacktrace
2015-07-12 13:57:15 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-12 13:57:19 +0000 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3fb600e80350"
  2015-07-12 13:57:15 +0000 [warn]: suppressed same stacktrace
2015-07-12 13:57:19 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-12 13:57:27 +0000 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3fb600e80350"
  2015-07-12 13:57:19 +0000 [warn]: suppressed same stacktrace
2015-07-12 13:57:27 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-07-12 13:57:41 +0000 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3fb600e80350"
  2015-07-12 13:57:27 +0000 [warn]: suppressed same stacktrace
```