### PR TITLE
Add connection reset/connection aborted error handling

### DIFF
--- a/lib/fluent/plugin/out_logentries.rb
+++ b/lib/fluent/plugin/out_logentries.rb
@@ -128,7 +128,7 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
     retries = 0
     begin
       client.write("#{token} #{data} \n")
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EPIPE => e
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ECONNABORTED, Errno::ETIMEDOUT, Errno::EPIPE => e
       if retries < @max_retries
         retries += 1
         @_socket = nil


### PR DESCRIPTION
When we used this, error occurred as below.
I think additional error handling needed.

```
2016-03-31 07:29:03 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2016-03-31 07:29:04 +0900 error_class="Errno::ECONNRESET" error="Connection reset by peer" plugin_id="object:3f821f62ca4c"
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/openssl/buffering.rb:326:in `syswrite'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/openssl/buffering.rb:326:in `do_write'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/openssl/buffering.rb:344:in `write'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:129:in `send_logentries'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:121:in `block in write'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/plugin/buf_memory.rb:61:in `feed_each'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/plugin/buf_memory.rb:61:in `msgpack_each'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-logentries-0.2.10/lib/fluent/plugin/out_logentries.rb:112:in `write'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:325:in `write_chunk'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/buffer.rb:304:in `pop'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/output.rb:321:in `try_flush'
  2016-03-31 07:29:03 +0900 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.12/lib/fluent/output.rb:140:in `run'
2016-03-31 07:29:04 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2016-03-31 07:29:06 +0900 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3f821f62ca4c"
  2016-03-31 07:29:04 +0900 [warn]: suppressed same stacktrace
2016-03-31 07:29:06 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2016-03-31 07:29:09 +0900 error_class="OpenSSL::SSL::SSLError" error="SSL_write: bad write retry" plugin_id="object:3f821f62ca4c"
...
```