### PR TITLE
Add new settings: `app_name` and `token_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ install with gem or fluent-gem command as:
 ```yaml
     My-Awesome-App:
        app: MY-LOGENTRIES-TOKEN
-       access: ANOTHER-LOGENTRIES-TOKEN (*)
-       error: ANOTHER-LOGENTRIES-TOKEN-1 (*)
+       stdout: ANOTHER-LOGENTRIES-TOKEN (*)
+       stderr: ANOTHER-LOGENTRIES-TOKEN-1 (*)
     Another-app:
        app: 2bfbea1e-10c3-4419-bdad-7e6435882e1f
        access: 5deab21c-04b1-9122-abdc-09adb2eda22 (*)
        error: 9acfbeba-c92c-1229-ccac-12c58d82ecc (*)
 ```
-(*) `access` and `error` are optional, if you don't use multiple log per host just provide an app token.
+(\*) any token other than `app` is optional, if you don't use multiple log per host just provide an app token.
 
 This file is read on changes, it allows on fly modifications.
+
 ## Usage
 
 ```
@@ -42,23 +43,41 @@ This file is read on changes, it allows on fly modifications.
 ### type (required)
 The value must be `logentries`.
 
-### config_path (required)
+### config\_path (required)
 Path of your configuration file, e.g. `/opt/logentries/tokens.conf`
 
 ### protocol
 The default is `tcp`.
 
-### use_ssl
+### use\_ssl
 Enable/disable SSL for data transfers between Fluentd and Logentries. The default is `true`.
 
 ### port
 Only in case you don't use SSL, the value must be `80`, `514`, or `10000`. The default is `20000` (SSL)
 
-### max_retries
+### max\_retries
 Number of retries on failure.
 
-### tag_access_log, tag_error_log
+### use\_json
+When set to true, emit the entire record as a stringized JSON body instead of extracting the text from the `message` field of the record.
+
+### app\_name
+Used as a key for picking up a token set in the configuration file.  You can use placeholders that are compatible with fluent-plugin-record-modifier.
+
+The default value is `${record['app_name']}`.
+
+
+### token\_name
+Used as a key for picking up a token in the token set determined by `app_name`.  You can use placeholders that are compatible with fluent-plugin-record-modifier.
+
+The default value is `${tag == @tag_access_log ? 'access': tag == @tag_error_log ? 'error': 'app'}`
+
+
+### tag\_access\_log, tag\_error\_log **(deprecated)**
 This is use in case you tag your access/error log and want them to be push into another log.
+
+You can now use an arbitrary key to specify the token by giving an express to `token_name` setting.
+
 
 ## Contributing
 

--- a/lib/fluent/plugin/out_logentries.rb
+++ b/lib/fluent/plugin/out_logentries.rb
@@ -14,6 +14,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :protocol,       :string,  :default => 'tcp'
   config_param :config_path,    :string
   config_param :max_retries,    :integer, :default => 3
+  config_param :app_name,       :string,  :default => %q(${record['app_name']})
+  config_param :token_name,     :string,  :default => %q(${tag == @tag_access_log ? 'access': tag == @tag_error_log ? 'error': 'app'})
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
@@ -24,8 +26,10 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def configure(conf)
     super
 
-    @tokens    = nil
-    @last_edit = Time.at(0)
+    @tokens          = nil
+    @last_edit       = Time.at(0)
+    @app_name_expr   = DynamicExpander.new('app_name', @app_name)
+    @token_name_expr = DynamicExpander.new('token_name', @token_name)
   end
 
   def start
@@ -57,7 +61,7 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
 
   # This method is called when an event reaches Fluentd.
   def format(tag, time, record)
-    return [tag, record].to_msgpack
+    return [tag, time, record].to_msgpack
   end
 
   # Parse an YML file and generate a list of tokens.
@@ -78,8 +82,9 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   end
 
   # Returns the correct token to use for a given tag / records
-  def get_token(tag, record)
-    app_name = record["app_name"] || ''
+  def get_token(tag, time, record, tag_parts)
+    app_name = @app_name_expr.expand(tag, time, record, tag_parts, self) || ''
+    token_name = @token_name_expr.expand(tag, time, record, tag_parts, self)
 
     # Config Structure
     # -----------------------
@@ -87,23 +92,11 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
     #   app: TOKEN
     #   access: TOKEN (optional)
     #   error: TOKEN  (optional)
-    @tokens.each do |key, value|
+    return @tokens.each do |key, value|
       if app_name == key || tag.index(key) != nil
-        default = value['app']
-
-        case tag
-          when @tag_access_log
-            return value['access'] || default
-          when @tag_error_log
-            return value['error']  || default
-
-          else
-            return default
-        end
+        break value[token_name] || value['app']
       end
-    end
-
-    return default_token
+    end || default_token
   end
 
   # NOTE! This method is called by internal thread, not Fluentd's main thread. So IO wait doesn't affect other plugins.
@@ -111,11 +104,13 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
     generate_tokens_list()
     return unless @tokens.is_a? Hash
 
-    chunk.msgpack_each do |tag, record|
+    chunk.msgpack_each do |tag, time, record|
       next unless record.is_a? Hash
       next unless @use_json or record.has_key? "message"
 
-      token = get_token(tag, record)
+      tag_parts = tag.split('.')
+
+      token = get_token(tag, time, record, tag_parts)
       next if token.nil?
 
       # Clean up the string to avoid blank line in logentries
@@ -146,4 +141,52 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
     end
   end
 
+  # stolen from https://github.com/repeatedly/fluent-plugin-record-modifier
+  class DynamicExpander
+    def initialize(param_key, param_value)
+      if param_value.include?('${')
+        __str_eval_code__ = parse_parameter(param_value)
+
+        # Use class_eval with string instead of define_method for performance.
+        # It can't share instructions but this is 2x+ faster than define_method in filter case.
+        # Refer: http://tenderlovemaking.com/2013/03/03/dynamic_method_definitions.html
+        (class << self; self; end).class_eval <<-EORUBY,  __FILE__, __LINE__ + 1
+          def expand(tag, time, record, tag_parts, outer)
+            outer.instance_eval { #{__str_eval_code__} }
+          end
+        EORUBY
+      else
+        @param_value = param_value
+      end
+
+      begin
+        # check eval genarates wrong code or not
+        expand(nil, nil, nil, nil, nil)
+      rescue SyntaxError
+        raise ConfigError, "Pass invalid syntax parameter : key = #{param_key}, value = #{param_value}"
+      rescue
+        # Ignore other runtime errors
+      end
+    end
+
+    # Default implementation for fixed value. This is overwritten when parameter contains '${xxx}' placeholder
+    def expand(tag, time, record, tag_parts, outer)
+      @param_value
+    end
+
+    private
+
+    def parse_parameter(value)
+      num_placeholders = value.scan('${').size
+      if num_placeholders == 1
+        if value.start_with?('${') && value.end_with?('}')
+          return value[2..-2]
+        else
+          "\"#{value.gsub('${', '#{')}\""
+        end
+      else
+        "\"#{value.gsub('${', '#{')}\""
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch adds the following configuration directives and deprecates `tag_access_log` and `tag_error_log` directives.

* app\_name

  Used as a key for picking up a token set in the configuration file.  You can use placeholders that are compatible with fluent-plugin-record-modifier.

  The default value is `${record['app_name']}`.

* token\_name

  Used as a key for picking up a token in the token set determined by `app_name`.  You can use placeholders that are compatible with fluent-plugin-record-modifier.

  The default value is `${tag == @tag_access_log ? 'access': tag == @tag_error_log ? 'error': 'app'}`

